### PR TITLE
fix incorrect url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Usage
 
 ```javascript
 
-<script type="text/javascript" src="https://cdn.prix.ai/prix_collection.js"></script>
+<script type="text/javascript" src="https://cdn.prix.ai/prix-collection.js"></script>
 <script type="text/javascript">
     prix.send_event({
         type: "sale",


### PR DESCRIPTION
https://cdn.prix.ai/prix_collection.js returns a 403

whereas 

https://cdn.prix.ai/prix-collection.js returns 200